### PR TITLE
Changes display reset in grid system module

### DIFF
--- a/src/styles/5-objects/grid-system.scss
+++ b/src/styles/5-objects/grid-system.scss
@@ -18,7 +18,7 @@
       &-#{$col-number}--#{$size} {
         // TODO is 'flex: 0 0 column-size($col-number)' better?
         flex: column-size($col-number);
-        display: initial;
+        display: unset;
       }
     }
   }


### PR DESCRIPTION
 - Using display: initial led to the CSS optimizer wrongfully affecting
    the production CSS for the grid system. display: unset does not
    have this effect since it simply performs an undo.