### PR TITLE
Fixes CSS load order

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -485,7 +485,8 @@ module.exports = function(webpackEnv) {
                     name: 'sass-resources-loader',
                     options: {
                       resources: [
-                        path.join(paths.appSrc, '/styles/main.scss'),
+                        path.join(paths.appSrc, '/styles/1-settings/1-settings.scss'),
+                        path.join(paths.appSrc, '/styles/2-tools/2-tools.scss'),
                       ],
                     },
                   },
@@ -517,7 +518,8 @@ module.exports = function(webpackEnv) {
                     name: 'sass-resources-loader',
                     options: {
                       resources: [
-                        path.join(paths.appSrc, '/styles/main.scss'),
+                        path.join(paths.appSrc, '/styles/1-settings/1-settings.scss'),
+                        path.join(paths.appSrc, '/styles/2-tools/2-tools.scss'),
                       ],
                     },
                   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import Router from 'components/router/router';
-
 // Load fonts into bundle
 // TODO move into 'font-loader' module
 import 'fonts/noto-sans/noto-sans-regular.eot';
@@ -24,6 +22,11 @@ import 'fonts/noto-sans/noto-sans-bold-italic.woff2';
 
 import * as serviceWorker from './serviceWorker';
 import initPreAppModule from 'modules/pre-app';
+
+// Load global styles
+import 'styles/main.scss';
+
+import Router from 'components/router/router';
 
 initPreAppModule();
 

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1,5 +1,4 @@
-@import './1-settings/1-settings.scss';
-@import './2-tools/2-tools.scss';
+// First two layers are loaded by 'sass-resources-loader'
 @import './3-generic/3-generic.scss';
 @import './4-elements/4-elements.scss';
 @import './5-objects/5-objects.scss';


### PR DESCRIPTION
 - CSS for features was being loaded first because the Router component
    (and all its children) was above the global styles import.
 - SASS variables/mixins are loaded to every SASS file, through
    sass-resources-loader.